### PR TITLE
fixing rotate safari bug

### DIFF
--- a/src/donutty.js
+++ b/src/donutty.js
@@ -209,7 +209,7 @@
         this.$svg.setAttribute( "xmlns", namespace );
         this.$svg.setAttribute( "viewbox", "0 0 " + viewbox + " " + viewbox );
         this.$svg.setAttribute( "width", "100%" );
-        this.$svg.setAttribute( "transform", "scale( " + scale + " ) rotate( " + rotate + " )" );
+        this.$svg.setAttribute( "style", "transform: scale(" + scale + ") rotate(" + rotate + "deg)" );
         this.$svg.setAttribute( "preserveAspectRatio", "xMidYMid meet" );
         this.$svg.setAttribute( "class", "donut" );
         this.$svg.setAttribute( "role", "img" );


### PR DESCRIPTION
[i found this.](https://stackoverflow.com/questions/48248512/svg-transform-rotate180-does-not-work-in-safari-11)

i transferred it to inline css.
so it looks good.

https://codepen.io/kukac7/pen/rNGOKvJ

![Screenshot 2021-12-04 at 20 27 23](https://user-images.githubusercontent.com/1240104/144722170-7815370f-b17a-44ca-a8c8-5010d546b4a4.png)